### PR TITLE
Convert rendered PNG to JPEG by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/var/cache/pacman/pkg,sharing=locked \
     pacman -Sy --noconfirm archlinux-keyring && \
     pacman -Su --noconfirm && \
     pacman -S --noconfirm \
-        python-aiogram typst \
+        python-aiogram python-pillow typst \
         fontconfig ttf-dejavu ttf-roboto tex-gyre-fonts \
         noto-fonts noto-fonts-cjk noto-fonts-extra
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     image: ghcr.io/daskol/typst-telegram-bot:0.2.1
     build: .
     command: 'python -m typst_telegram serve api -d data -e http://api:8080 -i 0.0.0.0'
+    ports:
+      - '127.0.0.1:8080:8080'
     security_opt:
       - 'no-new-privileges:true'
     user: 'nobody:nobody'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Utilities",
     "Typing :: Typed",
 ]
-dependencies = ["aiogram>=3", "aiohttp"]
+dependencies = ["aiogram>=3", "aiohttp", "pillow"]
 requires-python = ">=3.11,<4"
 
 [project.optional-dependencies]

--- a/typst_telegram/api.py
+++ b/typst_telegram/api.py
@@ -8,6 +8,8 @@ from aiohttp.web import (HTTPBadRequest, HTTPRequestEntityTooLarge, Request,
 
 from typst_telegram.render import EXPR_MAX_SIZE, Context, RenderingError
 
+MIME = {'jpeg': 'image/jpeg', 'png': 'image/png'}
+
 
 async def get_ping(request):
     return Response(text='Pong.\n')
@@ -21,16 +23,25 @@ async def get_render(request: Request):
     elif len(expr) > EXPR_MAX_SIZE:
         raise HTTPRequestEntityTooLarge(EXPR_MAX_SIZE, len(expr))
 
+    accept = request.headers.get('Accept', 'image/jpeg')
+    if accept.startswith('image/png'):
+        fmt = 'png'
+    elif accept.startswith('image/jpeg') or accept == '*/*':
+        fmt = 'jpeg'
+    else:
+        desc = f'Unexpected "Accept" header: {accept}.\n'
+        raise HTTPBadRequest(body=desc, content_type='text/plain')
+
     config: dict[str, Any] = request.app.config
     context = Context(root_dir=config['root_dir'], dpi=config.get('ppi'),
                       margin=config.get('margin'))
 
     try:
-        img = await context.render(expr)
+        img = await context.render(expr, format=fmt)
     except RenderingError as e:
         json = dumps(e.to_dict(), ensure_ascii=False)
         raise HTTPBadRequest(body=json, content_type='application/json') from e
-    return Response(body=img)
+    return Response(body=img, content_type=MIME[fmt])
 
 
 app = web.Application()

--- a/typst_telegram/bot.py
+++ b/typst_telegram/bot.py
@@ -2,6 +2,7 @@ import logging
 from hashlib import md5
 from http import HTTPStatus
 from os import getenv
+from urllib.parse import quote
 
 from aiogram import Bot, Dispatcher, types
 from aiogram.exceptions import TelegramBadRequest
@@ -108,23 +109,29 @@ async def handle_callback_query(query: types.CallbackQuery):
 
 
 @router.inline_query()
-async def render_inline(message: types.InlineQuery,
+async def render_inline(message: types.InlineQuery, public_url: str,
                         stats: UserStats | None = None):
     if stats is not None and message.from_user is not None:
         stats.record(message.from_user.id, message.from_user.username,
                      message.from_user.first_name)
     text = message.query or 'F(x) = integral f(x) d x + C'
-    input_content = types.InputTextMessageContent(message_text=text)
     result_id: str = md5(text.encode()).hexdigest()
-    item = types.InlineQueryResultArticle(
+    photo_url = f'{public_url}/render?expr={quote(text, safe="")}'
+    item = types.InlineQueryResultPhoto(
         id=result_id,
         title=text,
-        input_message_content=input_content,
+        photo_url=photo_url,
+        thumbnail_url=photo_url,
+        cache_time=600,
     )
     await message.answer(results=[item])
 
 
-async def serve(endpoint: str, stats: UserStats | None = None):
+
+async def serve(endpoint: str, public_url: str,
+                stats: UserStats | None = None):
     async with ClientSession(endpoint) as sess:
-        await router.start_polling(bot, skip_updates=True, sess=sess,
-                                   stats=stats)
+        mask = ['message', 'callback_query', 'inline_query']
+        await router.start_polling(
+            bot, skip_updates=True, allowed_updates=mask, sess=sess,
+            stats=stats, public_url=public_url)

--- a/typst_telegram/cli.py
+++ b/typst_telegram/cli.py
@@ -117,7 +117,7 @@ async def serve_bot(ns: Namespace):
     stats = None
     if ns.stats_file is not None:
         stats = UserStats(ns.stats_file)
-    await serve(ns.endpoint, stats=stats)
+    await serve(ns.endpoint, ns.public_url, stats=stats)
 
 
 def version(ns: Namespace):
@@ -221,6 +221,9 @@ p_serve_bot.set_defaults(func=serve_bot)
 p_serve_bot.add_argument(
     '-e', '--endpoint', type=str, default='http://localhost:8080',
     help='rendering service endpoint')
+p_serve_bot.add_argument(
+    '--public-url', type=str, required=True, metavar='URL',
+    help='public base URL of the server (e.g. https://example.com)')
 p_serve_bot.add_argument(
     '-s', '--stats-file', type=Path, default=None, metavar='PATH',
     help='base path for user stats CSV files')

--- a/typst_telegram/render.py
+++ b/typst_telegram/render.py
@@ -5,9 +5,12 @@ from asyncio.subprocess import PIPE, create_subprocess_exec
 from codecs import getincrementaldecoder
 from dataclasses import dataclass
 from functools import partial
+from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
+
+from PIL import Image
 
 EXPR_TEMPLATE = """\
 #set page(width: auto, height: auto, margin: {margin})
@@ -56,15 +59,14 @@ class Context:
 
     dpi: int = 300
 
-    mimetype: str = 'image/png'
-
     margin: str = '0.3em'
 
-    async def render(self, expr: str):
+    async def render(self, expr: str, format: str = 'jpeg') -> bytes:
         with TemporaryDirectory(dir=self.root_dir) as tmpdir:
-            return await self.render_at(expr, Path(tmpdir))
+            return await self.render_at(expr, Path(tmpdir), format=format)
 
-    async def render_at(self, expr: str, root_dir: Path):
+    async def render_at(self, expr: str, root_dir: Path,
+                        format: str = 'jpeg') -> bytes:
         path_typ = root_dir / 'main.typ'
         path_png = root_dir / 'main.png'
 
@@ -89,4 +91,12 @@ class Context:
             raise RenderingError(**kwargs)
 
         with open(path_png, 'rb') as fout:
-            return fout.read()
+            data = fout.read()
+
+        if format == 'jpeg':
+            img = Image.open(BytesIO(data)).convert('RGB')
+            buf = BytesIO()
+            img.save(buf, format='JPEG', quality=90)
+            data = buf.getvalue()
+
+        return data


### PR DESCRIPTION
Resolve #6 

Telegram Bot API say that inline result should provide an URL to JPEG (not PNG) image. This PR adds handling of rendering requests depending on `Accept` header. Also, it exposes rendering API on public for Telegram backend.